### PR TITLE
Read "measurement" value from config file

### DIFF
--- a/src/Command/InfluxCommand.php
+++ b/src/Command/InfluxCommand.php
@@ -121,11 +121,9 @@ EOD;
 	}
 
 	protected function influxLastTimestamp(array $entity): float {
-		$iql = <<<EOD
-SELECT last(value)
-FROM data
-WHERE uuid = '%s'
-EOD;
+		$iql = sprintf(
+			'SELECT last(value) FROM %s WHERE "uuid"=\'%%s\'',$this->getConfig('influx.measurement')
+		);
 
 		$res = $this->influxQuery(sprintf($iql, $entity['uuid']));
 		$timestamp = count($res) ? $res[0]['time'] : 0;


### PR DESCRIPTION
Overwrite preset influx measurement name with the one from the config file.
This restores expected behavior.